### PR TITLE
CI: rm --enable-pydarshan

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -52,7 +52,7 @@ jobs:
           git submodule update --init
           ./prepare.sh
           cd darshan-util
-          ./configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-pydarshan --enable-apxc-mod --enable-apmpi-mod
+          ./configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-apxc-mod --enable-apmpi-mod
           make
           make install
       - name: Install pydarshan


### PR DESCRIPTION
* remove the redundant `--enable-pydarshan` used at the config
stage because we are already doing `python setup.py install` later
on, and because we may want to switch that to a "wheel-style" install
with `pip install .` when that works well with autoperf later on

* this simply mirrors:
https://github.com/darshan-hpc/darshan/pull/504

* also, just curious to see if we can now trigger the CI
automatically with PRs to the logs repo