### PR TITLE
CI: try adding Python 3.6

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install pydarshan
         run: |
           cd scratch/darshan/darshan-util/pydarshan
-          python -m pip install . --use-feature=in-tree-build
+          python -m pip install .
       # shim for importlib.resources on Python < 3.9
       - if: ${{matrix.python-version < 3.9}}
         name: Install importlib_resources
@@ -72,4 +72,4 @@ jobs:
           # the test suite is sensitive to
           # relative dir for test file paths
           cd scratch/darshan/darshan-util/pydarshan
-          pytest
+          pytest --import-mode=importlib 

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
           python -m pip install --upgrade pytest
           # matplotlib is pinned because of
           # gh-479
-          python -m pip install matplotlib==3.4.3
+          python -m pip install 'matplotlib<3.5'
       - if: ${{matrix.platform == 'macos-latest'}}
         name: Install MacOS deps
         run: |
@@ -58,8 +58,7 @@ jobs:
       - name: Install pydarshan
         run: |
           cd scratch/darshan/darshan-util/pydarshan
-          # TODO: use pip per gh-476
-          python setup.py install
+          python -m pip install . --use-feature=in-tree-build
       # shim for importlib.resources on Python < 3.9
       - if: ${{matrix.python-version < 3.9}}
         name: Install importlib_resources

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip 
-          python -m pip install --upgrade pytest
+          python -m pip install --upgrade pytest lxml
           # matplotlib is pinned because of
           # gh-479
           python -m pip install 'matplotlib<3.5'


### PR DESCRIPTION
The CI is already out of date from the improvements in the main repo, but the main thing I want to do is see what goes wrong if we try adding Python `3.6` here, to enforce the Argonne support requirement to the logs repo as well.