### PR TITLE
example large file and infrastructure to download large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Repository of example Darshan log files.  Each is in a subdirectory with
 it's own README.md describing why that specific log is a notable example.
 
-If a Darshan log is to large to store directly in the git repository, then
+If a Darshan log is too large to store directly in the git repository, then
 the directory will contain a `*.darshan.link` file rather than a `*.darshan`
 file.  The link file is just a text file containing the URL to the example
 in an externally hosted download site.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # darshan-logs
-Repository of example Darshan log files of interest
+
+Repository of example Darshan log files.  Each is in a subdirectory with
+it's own README.md describing why that specific log is a notable example.
+
+If a Darshan log is to large to store directly in the git repository, then
+the directory will contain a `*.darshan.link` file rather than a `*.darshan`
+file.  The link file is just a text file containing the URL to the example
+in an externally hosted download site.
+
+You can download all such files at once by running the
+`download-large-logs.sh` script at the top level of this repository.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ in an externally hosted download site.
 
 You can download all such files at once by running the
 `download-large-logs.sh` script at the top level of this repository.
+This script will also set the correct path/name for each log so that there
+is a corresponding `*.darshan` file alongside each `*.darshan.link` file in
+the repository.

--- a/darshan_logs/large_log/README.md
+++ b/darshan_logs/large_log/README.md
@@ -1,0 +1,11 @@
+This example is an anonymized version of the largest Darshan log generated
+on the Theta system at the ALCF in the month of October 2021.
+
+The log has been anonymized, converted to bzip2 compression, and is hosted
+as an external download.  It can be downloaded from the link listed in the
+theta-large-anonymized-example-2021-bz2.darshan.link file in this
+subdirectory.  After downloading, rename the resulting file to
+theta-large-anonymized-example-2021-bz2.darshan.
+
+You can also download all such large files in this repository in bulk using
+the `download-large-logs.sh` script at the top level of this repository.

--- a/darshan_logs/large_log/theta-large-anonymized-example-2021-bz2.darshan.link
+++ b/darshan_logs/large_log/theta-large-anonymized-example-2021-bz2.darshan.link
@@ -1,0 +1,1 @@
+https://anl.box.com/shared/static/rny55tyu7nphla8t06cpq41j6dv9bm8c

--- a/download-large-logs.sh
+++ b/download-large-logs.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if ! command -v wget &> /dev/null
+then
+    echo "Error: this script requires the wget utility."
+    exit
+fi
+
 echo status:
 for LINKFILE in `find . -name "*.link"`; do
     DARSHANFILE=${LINKFILE%.link}

--- a/download-large-logs.sh
+++ b/download-large-logs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo status:
+for LINKFILE in `find . -name "*.link"`; do
+    DARSHANFILE=${LINKFILE%.link}
+    echo "    ${DARSHANFILE}"
+    if [ -f $DARSHANFILE ] ; then
+        echo "        - already present, skipping."
+    else
+        echo "        - not present, downloading..."
+        wget -nv `cat $LINKFILE` -O $DARSHANFILE
+    fi
+done
+echo done.


### PR DESCRIPTION
@shanedsnyder @tylerjereddy @nawtrey

I'd like some feedback on this approach.  We can merge this PR if it seems helpful, or close it and try something different if not.

This PR adds a large darshan log example (it has been anonymized and converted to bz2 format, producing a 204 MiB file from an original that was 544 MiB in size).  Possibly useful for performance testing of analysis routines.

The log is too large to store in a github repository directly, so instead the example includes a link to it.  There is a top-level shell script that will find all such links and download them at once if you want to populate all such files:

```
> ./download-large-logs.sh
status:
    ./darshan_logs/large_log/theta-large-anonymized-example-2021-bz2.darshan
        - not present, downloading...
2021-11-04 16:22:07 URL:https://public.boxcloud.com/d/1/b1!IpOZrgBIqyA9paQgsc7VMUcTgsFnL9NZg_mWo1DBK6QKjtLR1J3N2qdqTJJGLKWRiRRVWKAY28AlkQDQG9OeUNtPs-Tto8rCov6roTsHoV1n-QwsNJii_DkOQ14ceLfFkqEm6VAcs_a_w2ZTgSi1GnW0Ek_GAXCEgkpW3GNub6eynHdx0fnjpjsYm2uhcuR-B4DLnAMChpCNcqdddQRdQl8xy1a8rn7jCKst0g8p7B4zA_6LVm32dFWsFx7wt7d35YpbCVUGVLJYw6dAtbtUq45AubjnAfMKehKM38NpHaY3XHd-fwVHQQokhd8b9SKnhN3jd-Jw1HOuyVVSK_DY17odEeNcvCrLokFXzkDGU1JeAVxWGD-OU5jVOxzfU8apBkWAkt87PmEeyA4sxaT5zZ3ywcmeBBWZTMXZKbZZ6RdfZ-5wZUKLdov0oWvz5mynKwqzNTjUrN6Gis7ENozjMYKJdoAXHnQBIFeaXoUQo84WtDzV_Qk5yS5fQJ8tqn0ltu-YHzJsYAlBsLN_iOmnliCn8VaQ3Kx-McvVSwo2fpkTKOOK5FFNKX11Is6H7wysLNn7aqR61p_YvgRMgL23QTzGwv-Tk64fc1yOKUCJckKfRLJ2qqMLpUuLo4k9hg598s6eD4Fn8KpNMTSAQByhk3BZyuD_EmVxf-b2uSVd0dKHVkfesiJK6__NgbfEw-a9Zav-BO1SaOVnM_4tcMFjr-r3KPxgT82GFMqdd5S1CHo4ndgukBKyHoZ8TWMxPPzRzvRdbguzo0eskmcfFtsX3iQ-byOaAKGchXdbmFwd05Dws6jxhiEyMVjc2o-Jnji_2FFWKyR5UbK25ZD1WakRBGZ7_ngshEBa-3oW3r8xnd8Utcs5AqPpH5MUopfqMMuJPD74SGHbh9u7aSAXFDg9WDklwOGDzzzlbWVtYpkri0mUt7Chzlv4bl7nFVUCVuMI2Ttj0eijTRkLkQoX0q7A88MJEYz2o7cqK2_ZtM8gZ6-4YsriSLJcOghd4EnHReAuG4GBIh_TKZE6ywmPJEF80aLnSSgQslEmTVn4P2lyrvKbXn1JMi91yVmdypS2jZ4nZdFX-ijtEPnsQr1N5a1awts4O-hPmZjJb3PXfZWC_Cw0x_-ypxmkFUGSs00VFSQXCOS1AHlTTfGMiYMHw95i_NeuPliuHckb8_h-XBS0Tv9mWrN8PlOwWaZ2ouXT6KkqAuGgoJ3Z_I7dPWZqmraPj7gYboMtsSCVxKX2L6jwp-IO6ifUCdhpawyL_v8Gb7o-1hXulTak5H7OABERxIkvNyVpF-wTsG7SDy_phn4dCDbDMdbSkwHqoG4AbGPhGLSQoGtDaTLHA1ToSH-M6aW5ll4JywkxyC8Q6_RGyZ7ebu1Gpzme5dUVH4XDQsaFt7cGE98O1ARCEZ5FzoeEMUNrjFeBK1kmLBAuAI5U-wYMjVYSv3VYEwwFhEmCMn2WgI7cgfgB5XSts0fjPVL4Rl3E/download [213280253/213280253] -> "./darshan_logs/large_log/theta-large-anonymized-example-2021-bz2.darshan" [1]
done.
```
One possible snag is that it will only go as fast as the hosting service used for the large files.  This example is hosted on a public Box share link and takes over 4 minutes to download for me.  If the downloads are that slow, then this probably isn't feasible for CI actions that run frequently; it would be more for one-off testing, or environments where the darshan_logs can be downloaded to a static location and just updated rather than re-downloaded.