### PR TITLE
CI: add Python 3.10 to CI.

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add Python `3.10` to logs repo CI to mirror the same addition to the main repo CI in https://github.com/darshan-hpc/darshan/pull/515

This is likely to work now since I'm putting the SciPy `1.7.2` release out this evening and the binary wheels are up on PyPI for `3.10`.