### PR TITLE
BLD: pyproject.toml fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ requires = [
 
 [project]
 name = "darshan_logs"
-
-requires-python = ">=3.7"
+dynamic = ["version"]
+requires-python = ">=3.6"
 
 [project.urls]
 source = "https://github.com/darshan-hpc/darshan-logs"


### PR DESCRIPTION
Fixes #31 

* allow `version` to be specified dynamically from the
project for now since `setuptools` seems to be getting
stricter about leaving out the `version` field now; we
could also pin `setuptools` version if we prefer

* we still support Python `3.6`, unfortunately, so adjust
the minimum bound for Python while I'm in the neighborhood