### PR TITLE
CI: bump GitHub actions versions

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       # install this (logs) project


### PR DESCRIPTION
* [follow NumPy](https://github.com/numpy/numpy/pull/21307) in bumping to the latest versions
of these actions