### PR TITLE
CI, MAINT: point to main branch

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -26,13 +26,11 @@ jobs:
       - name: Install darshan_logs package
         run: |
           python -m pip install .
-      - name: obtain pydarshan pydarshan-devel branch
+      - name: obtain pydarshan
         run: |
           mkdir scratch
           cd scratch
           git clone https://github.com/darshan-hpc/darshan.git
-          cd darshan
-          git checkout pydarshan-devel
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
* we should be able to point to the `main` branch of
the primary repo following the merge of `pydarshan-devel`
over there, so simplify that in our CI workflow here