### PR TITLE
MAINT, CI: 3.11 and mpl unpin

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
@@ -36,10 +36,7 @@ jobs:
           python -m pip install --upgrade pip
           # pytest is pinned because of gh-24
           python -m pip install --upgrade 'pytest==6.2.5'
-          python -m pip install --upgrade lxml
-          # matplotlib is pinned because of
-          # gh-479
-          python -m pip install 'matplotlib<3.5'
+          python -m pip install --upgrade lxml matplotlib
       - if: ${{matrix.platform == 'macos-latest'}}
         name: Install MacOS deps
         run: |


### PR DESCRIPTION
* we should be able to unpin `matplotlib` in the logs repo CI now that the main repo code issue has been dealt with:
https://github.com/darshan-hpc/darshan/issues/479

* also, Python `3.11` is imminent so add it to the CI with the same justifiation as main repo PR:
https://github.com/darshan-hpc/darshan/pull/823